### PR TITLE
Bump diff to 4.* to resolve github warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "disparity",
+  "version": "2.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "diff": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,10 +31,11 @@
   "homepage": "https://github.com/millermedeiros/disparity",
   "dependencies": {
     "ansi-styles": "^2.0.1",
-    "diff": "^1.3.2"
+    "diff": "^4.0.1"
   },
   "jshintConfig": {
     "node": true,
     "eqnull": true
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
I use [documentation](https://github.com/documentationjs/documentation), which uses [disparity](https://github.com/millermedeiros/disparity), which uses [diff](https://github.com/kpdecker/jsdiff) from four years ago (1.3.2 vs 4.0.1 current)

An obscure bug is marked high severity (wrongly) on Github's warning system.  Bumping `diff` fixes it with no code changes.  Tests continue to pass.  

Fixes #3 

Caused by [this](https://github.com/kpdecker/jsdiff/commit/2aec4298639bf30fb88a00b356bf404d3551b8c0)

![image](https://user-images.githubusercontent.com/77482/60633605-56f9bd80-9dc0-11e9-9319-e13ce5a239c4.png)

Thanks kindly