### PR TITLE
feat: support `context` option in unified functions

### DIFF
--- a/disparity.js
+++ b/disparity.js
@@ -146,7 +146,7 @@ function unifiedNoColor(str1, str2, opts) {
   var path1 = opts.paths && opts.paths[0] || '';
   var path2 = opts.paths && opts.paths[1] || path1;
 
-  var changes = stringDiff.createPatch('', str1, str2, '', '');
+  var changes = stringDiff.createPatch('', str1, str2, '', '', { context: opts.context });
 
   // remove first 2 lines (header)
   changes = changes.replace(/^([^\n]+)\n([^\n]+)\n/m, '');


### PR DESCRIPTION
`diff` supports `context` in the same way `disparity` does, so you can pass it straight through to `diff.createPatch` to support the same behaviour.

`diff` will default to `4` if `context` is `undefined`, so this shouldn't be breaking.